### PR TITLE
Fix: requestPermissions() on onStart() happens twice on the lifecycle

### DIFF
--- a/app/src/main/java/quevedo/soares/leandro/blemadeeasy/view/scandevices/ScanDevicesFragment.kt
+++ b/app/src/main/java/quevedo/soares/leandro/blemadeeasy/view/scandevices/ScanDevicesFragment.kt
@@ -58,11 +58,7 @@ class ScanDevicesFragment : Fragment() {
 
 		// Initialize the adapter
 		this.adapter = BLEDeviceAdapter(this.binding.fmdRvItems, this::onItemSelected)
-	}
-
-	override fun onStart() {
-		super.onStart()
-
+		
 		if (this.ble?.isScanRunning != true) requestPermissions()
 	}
 	// endregion


### PR DESCRIPTION
- moved requestPermissions() from onStart() to onViewCreated()
- closes #18 