### PR TITLE
Remove ACCESS_BACKGROUND_LOCATION for Android 11

### DIFF
--- a/lib/src/main/java/quevedo/soares/leandro/blemadeeasy/utils/PermissionUtils.kt
+++ b/lib/src/main/java/quevedo/soares/leandro/blemadeeasy/utils/PermissionUtils.kt
@@ -26,7 +26,7 @@ internal object PermissionUtils {
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
 			list.addAll(android12Permissions)
 		} else {
-			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) list.addAll(android10Permissions)
+			if (Build.VERSION.SDK_INT == Build.VERSION_CODES.Q) list.addAll(android10Permissions)
 
 			list.addAll(legacyPermissions)
 			list.addAll(locationPermissions)


### PR DESCRIPTION
- location permission prompt will only appear for Android 11 after removing ACCESS_BACKGROUND_LOCATION
- additional notes: 
- - ACCESS_BACKGROUND_LOCATION should only be included (for Android 10 devices) if the app is scanning for BLE devices in Foreground Service
- - ACCESS_BACKGROUND_LOCATION permission is not required if app scans for BLE devices in Activity